### PR TITLE
hadoop eclipse plugin for hadoop 2.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 hadoop2x-eclipse-plugin
 =======================
 
-eclipse plugin for hadoop 2.5.1
+eclipse plugin for hadoop  2.5.1
  
 
 How to build

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 hadoop2x-eclipse-plugin
 =======================
 
-eclipse plugin for hadoop 2.2.0
+eclipse plugin for hadoop 2.5.1
  
 
 How to build
@@ -9,11 +9,11 @@ How to build
 
   $cd src/contrib/eclipse-plugin 
 
-  $ant jar -Dversion=2.2.0 -Declipse.home=/opt/eclipse -Dhadoop.home=/usr/share/hadoop
+  $ant jar -Dversion=2.5.1 -Declipse.home=/opt/eclipse -Dhadoop.home=/usr/local/hadoop
 
 final jar will be genrated at directory 
 
-  $root/build/contrib/eclipse-plugin/hadoop-eclipse-plugin-2.2.0.jar
+  $root/build/contrib/eclipse-plugin/hadoop-eclipse-plugin-2.5.1.jar
 
 options required
 --------------------------------------

--- a/ivy/libraries.properties
+++ b/ivy/libraries.properties
@@ -1,20 +1,20 @@
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#       http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 #This properties file lists the versions of the various artifacts used by hadoop and components.
 #It drives ivy and the generation of a maven POM
 
 # This is the version of hadoop we are generating
-hadoop.version=2.2.0
+hadoop.version=2.5.1
 hadoop-gpl-compression.version=0.1.0
 
 #These are the versions of our dependencies (in alphabetical order)
@@ -29,43 +29,43 @@ checkstyle.version=4.2
 
 commons-cli.version=1.2
 commons-codec.version=1.4
-commons-collections.version=3.1
+commons-collections.version=3.2.1
 commons-configuration.version=1.6
 commons-daemon.version=1.0.13
-commons-httpclient.version=3.0.1
-commons-lang.version=2.5
-commons-logging.version=1.0.4
+commons-httpclient.version=3.1
+commons-lang.version=2.6
+commons-logging.version=1.1.3
 commons-logging-api.version=1.0.4
 commons-math.version=2.1
 commons-el.version=1.0
 commons-fileupload.version=1.2
-commons-io.version=2.1
+commons-io.version=2.4
 commons-net.version=3.1
-core.version=3.1.1
+core.version=1.8.0
 coreplugin.version=1.3.2
 
 hsqldb.version=1.8.0.10
 
 ivy.version=2.1.0
 
-jasper.version=5.5.12
-jackson.version=1.8.8
+jasper.version=5.5.23
+jackson.version=1.9.13
 #not able to figureout the version of jsp & jsp-api version to get it resolved throught ivy
 # but still declared here as we are going to have a local copy from the lib folder
 jsp.version=2.1
-jsp-api.version=5.5.12
+jsp-api.version=2.1
 jsp-api-2.1.version=6.1.14
 jsp-2.1.version=6.1.14
-jets3t.version=0.6.1
+jets3t.version=0.9.0
 jetty.version=6.1.26
 jetty-util.version=6.1.26
-jersey-core.version=1.8
-jersey-json.version=1.8
-jersey-server.version=1.8
-junit.version=4.5
+jersey-core.version=1.9
+jersey-json.version=1.9
+jersey-server.version=1.9
+junit.version=4.11
 jdeb.version=0.8
 jdiff.version=1.0.9
-json.version=1.0
+json.version=1.9
 
 kfs.version=0.1
 
@@ -79,7 +79,7 @@ oro.version=2.0.8
 
 rats-lib.version=0.5.1
 
-servlet.version=4.0.6
+servlet.version=2.5
 servlet-api.version=2.5
 slf4j-api.version=1.7.5
 slf4j-log4j12.version=1.7.5


### PR DESCRIPTION
Update hadoop eclipse plugin to build with hadoop 2.5.1
